### PR TITLE
feat: robot ürün listesine yeni sigorta ürünleri eklendi

### DIFF
--- a/versioned_docs/version-0.1.70/entegre-sigorta-urunleri/robot-urun-listesi.md
+++ b/versioned_docs/version-0.1.70/entegre-sigorta-urunleri/robot-urun-listesi.md
@@ -14,7 +14,7 @@ RPA yaklaşımı, API erişiminin mümkün olmadığı durumlarda süreçleri ot
 | ---- | ----- |
 | Aktif Şirket Sayısı | 20 (en az bir branşta entegrasyon olan) |
 | Branş Sayısı | 3 (Kasko, Trafik, TSS) |
-| Toplam Ürün Sayısı | 35 (her ✓ bir ürün entegrasyonunu temsil eder) |
+| Toplam Ürün Sayısı | 47 (her ✓ bir ürün entegrasyonunu temsil eder) |
 
 ## Entegre Robot Ürünleri
 
@@ -25,8 +25,8 @@ RPA yaklaşımı, API erişiminin mümkün olmadığı durumlarda süreçleri ot
 | Ak              | ✓     | ✓      |     |
 | Allianz         | ✓     | ✓      | ✓   |
 | Ana             |       |        |     |
-| Anadolu         |       |        |     |
-| Ankara          | ✓     |        |     |
+| Anadolu         |       |        | ✓   |
+| Ankara          | ✓     | ✓      | ✓   |
 | AtlasMutel      |       |        |     |
 | Aveon           |       |        |     |
 | Axa             |       |        |     |
@@ -41,23 +41,23 @@ RPA yaklaşımı, API erişiminin mümkün olmadığı durumlarda süreçleri ot
 | Groupama        |       |        |     |
 | Gulf            |       |        |     |
 | Halk            |       |        |     |
-| HDI             | ✓     | ✓      |     |
+| HDI             | ✓     | ✓      | ✓   |
 | Hepiyi          | ✓     | ✓      | ✓   |
 | Koru            | ✓     | ✓      |     |
 | Magdeburger     | ✓     | ✓      |     |
-| Mapfre          | ✓     |        |     |
+| Mapfre          | ✓     | ✓      |     |
 | Neova           |       |        |     |
 | Nippon          |       |        |     |
-| Orient          |       |        |     |
+| Orient          | ✓     |        |     |
 | Prive           |       |        |     |
-| Quick           | ✓     | ✓      |     |
+| Quick           | ✓     | ✓      | ✓   |
 | Ray             | ✓     | ✓      |     |
-| Sompo           | ✓     | ✓      |     |
+| Sompo           | ✓     | ✓      | ✓   |
 | Şeker           |       |        |     |
 | Tmt             |       |        |     |
-| Türkiye         | ✓     | ✓      |     |
-| Türkiye Katılım |       |        | ✓   |
-| Unico           | ✓     |        |     |
+| Türkiye         | ✓     | ✓      | ✓   |
+| Türkiye Katılım | ✓     | ✓      | ✓   |
+| Unico           | ✓     | ✓      |     |
 | Zurich          |       |        |     |
 
 **✓** işareti bulunan alanlar, ilgili sigorta şirketinin o branşta robot entegrasyonuna sahip olduğunu göstermektedir.


### PR DESCRIPTION
- Orient Kasko eklendi
- Ankara Trafik ve TSS eklendi
- Türkiye TSS eklendi
- Unico Trafik eklendi
- HDI TSS eklendi
- Mapfre Trafik eklendi
- Türkiye Katılım Kasko ve Trafik eklendi
- Sompo TSS eklendi
- Anadolu TSS eklendi
- Quick TSS eklendi

Toplam ürün sayısı 35'ten 47'ye güncellendi